### PR TITLE
dev-v0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ ehthumbs.db
 /app/logs/*
 /app/venv/*
 /app/conf/*
+/.dev/*.log
+/.dev/*.md
+/.dev/*.txt
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v ~/captn/conf:/app/conf \
   -v ~/captn/logs:/app/logs \
-  captnio/captn:0.8.6
+  captnio/captn:0.9.0
 ```
 
 ### 3. First Run (Dry-Run Mode)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "0.8.6"
+__version__ = "0.9.0"

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -315,7 +315,10 @@ def main():
                 f"Skipping container '{container.name}' - Assigned rule '{effective_rule}' does not allow any updates",
                 extra={"indent": 2},
             )
-            notification_manager.increment_skipped()
+            notification_manager.add_skip_detail(
+                container.name,
+                f"Assigned rule '{effective_rule}' does not allow any updates",
+            )
             continue
 
         notification_manager.increment_processed()
@@ -565,7 +568,10 @@ def main():
 
         elif not remote_image_tags:
             logging.info(f"No relevant image updates available for container '{container.name}'", extra={"indent": 2})
-            notification_manager.increment_skipped()
+            notification_manager.add_skip_detail(
+                container.name,
+                "No relevant image tags available from registry",
+            )
         else:
             error_msg = (
                 f"Missing required data for container '{container.name if container else 'UNKNOWN'}': "

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -17,6 +17,7 @@ from .utils.common import setup_logging
 from .utils.config import config, create_example_config
 from .utils.scripts import execute_pre_script, execute_post_script, should_continue_on_pre_failure, should_rollback_on_post_failure
 from .utils.notifiers import notification_manager
+from .utils.interrupt import install_interrupt_handlers
 
 
 def get_container_names():
@@ -269,6 +270,7 @@ def main():
         clear_logs()
 
     setup_logging(log_level=args.log_level, dry_run=dry_run)
+    install_interrupt_handlers()
 
     client = engines.get_client()
     if not client:
@@ -420,14 +422,13 @@ def main():
                             container.name,
                             dry_run,
                             update_type=update_type,
-                            old_version=image_metadata.get("tag") if image_metadata else None,
+                            old_version=current_tag,
                             new_version=remote_image_tag.get("name"),
                         )
                         if not pre_success and not should_continue_on_pre_failure():
                             error_msg = f"Pre-script failed for container '{container.name}'"
                             logging.error(error_msg, extra={"indent": 4})
                             notification_manager.add_error(error_msg)
-                            current_tag = image_metadata.get("tag") if image_metadata else "Unknown"
                             new_tag = remote_image_tag.get("name") if remote_image_tag else "Unknown"
                             update_duration = time.time() - update_start_time
                             notification_manager.add_update_detail(
@@ -475,8 +476,6 @@ def main():
                             )
                             break
                         else:
-                            # Prepare update info for potential failure tracking
-                            current_tag = image_metadata.get("tag") if image_metadata else "Unknown"
                             new_tag = remote_image_tag.get("name") if remote_image_tag else "Unknown"
 
                             new_container = engines.recreate_container(client, container, new_image_reference, container_inspect_data, dry_run, image_inspect_data, notification_manager, update_type=update_type, old_version=current_tag, new_version=new_tag)
@@ -608,4 +607,9 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    try:
+        main()
+    except KeyboardInterrupt:
+        logging.info("Interrupted by user, exiting...")
+        sys.exit(130)

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -345,7 +345,14 @@ def main():
         except Exception as e:
             error_msg = f"Failed to inspect container '{container.name}': {e}"
             logging.error(error_msg, extra={"indent": 2})
-            notification_manager.add_error(error_msg)
+            notification_manager.add_update_detail(
+                container_name=container.name,
+                old_version="Unknown",
+                new_version="Unknown",
+                update_type="unknown",
+                status="failed",
+                error_message=error_msg,
+            )
             continue
 
         # Debug logging with conditional formatting
@@ -431,7 +438,6 @@ def main():
                         if not pre_success and not should_continue_on_pre_failure():
                             error_msg = f"Pre-script failed for container '{container.name}'"
                             logging.error(error_msg, extra={"indent": 4})
-                            notification_manager.add_error(error_msg)
                             new_tag = remote_image_tag.get("name") if remote_image_tag else "Unknown"
                             update_duration = time.time() - update_start_time
                             notification_manager.add_update_detail(
@@ -440,7 +446,8 @@ def main():
                                 new_version=new_tag,
                                 update_type=update_type,
                                 duration=update_duration,
-                                status="failed"
+                                status="failed",
+                                error_message=error_msg,
                             )
                             continue
 
@@ -481,7 +488,7 @@ def main():
                         else:
                             new_tag = remote_image_tag.get("name") if remote_image_tag else "Unknown"
 
-                            new_container = engines.recreate_container(client, container, new_image_reference, container_inspect_data, dry_run, image_inspect_data, notification_manager, update_type=update_type, old_version=current_tag, new_version=new_tag)
+                            new_container, recreate_error = engines.recreate_container(client, container, new_image_reference, container_inspect_data, dry_run, image_inspect_data, notification_manager, update_type=update_type, old_version=current_tag, new_version=new_tag)
                             if new_container:
                                 try:
                                     # Refresh container and used image information
@@ -513,9 +520,6 @@ def main():
                                 except Exception as e:
                                     error_msg = f"Update failed for container '{new_container.name}': {e}"
                                     logging.error(error_msg, extra={"indent": 4})
-                                    notification_manager.add_error(error_msg)
-
-                                    # Add failed update to notification statistics
                                     update_duration = time.time() - update_start_time
                                     notification_manager.add_update_detail(
                                         container_name=new_container.name,
@@ -523,14 +527,12 @@ def main():
                                         new_version=new_tag,
                                         update_type=update_type,
                                         duration=update_duration,
-                                        status="failed"
+                                        status="failed",
+                                        error_message=error_msg,
                                     )
                             else:
-                                error_msg = f"Failed to recreate container '{container.name}'"
+                                error_msg = recreate_error or f"Failed to recreate container '{container.name}'"
                                 logging.error(error_msg, extra={"indent": 4})
-                                notification_manager.add_error(error_msg)
-
-                                # Add failed update to notification statistics
                                 update_duration = time.time() - update_start_time
                                 notification_manager.add_update_detail(
                                     container_name=container.name,
@@ -538,7 +540,8 @@ def main():
                                     new_version=new_tag,
                                     update_type=update_type,
                                     duration=update_duration,
-                                    status="failed"
+                                    status="failed",
+                                    error_message=error_msg,
                                 )
 
                         # 4. Wait for some seconds
@@ -583,7 +586,14 @@ def main():
                 f"{'remote_image_tags' if not remote_image_tags else ''}"
             )
             logging.error(error_msg, extra={"indent": 2})
-            notification_manager.add_error(error_msg)
+            notification_manager.add_update_detail(
+                container_name=container.name,
+                old_version=image_metadata.get("tag") if image_metadata else "Unknown",
+                new_version="Unknown",
+                update_type="unknown",
+                status="failed",
+                error_message=error_msg,
+            )
 
     # Handle self-updates at the very end to avoid interrupting other container updates
     if hasattr(main, "self_update_info") and main.self_update_info:

--- a/app/cli/captn.sh
+++ b/app/cli/captn.sh
@@ -44,16 +44,18 @@ else
   }
 
   # Trap to ensure lock is released on exit
-  trap 'rm -f "$LOCKFILE"; exit' INT TERM EXIT
+  trap 'rm -f "$LOCKFILE"' EXIT
 
-  timeout $TIMEOUT python -u -m app "$@"
+  if [ -t 0 ]; then
+    # Interactive session: run python directly
+    python -u -m app "$@"
+  else
+    timeout $TIMEOUT python -u -m app "$@"
+  fi
   EXIT_CODE=$?
 
-  # Release lock and remove lockfile manually
   rm -f "$LOCKFILE"
-
-  # Remove trap before exiting to avoid unnecessary deletion attempts
-  trap - INT TERM EXIT
+  trap - EXIT
 fi
 
 if [ $EXIT_CODE -eq 124 ]; then

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -67,6 +67,8 @@ DEFAULTS = {
     },
     "notifiers": {
         "enabled": "false",
+        "sendOn": "changes",
+        "sendOnDryRun": "true",
     },
     "notifiers.telegram": {
         "enabled": "false",
@@ -564,6 +566,13 @@ class Config:
             notifiers = self._namespaces["notifiers"]
             if hasattr(notifiers, "enabled") and not isinstance(notifiers.enabled, bool):
                 errors.append("notifiers.enabled must be a boolean (true/false)")
+            if hasattr(notifiers, "sendOn"):
+                valid_send_on = ("changes", "all")
+                send_on = notifiers.sendOn
+                if isinstance(send_on, str) and send_on.strip().lower() not in valid_send_on:
+                    errors.append(f"notifiers.sendOn must be one of: {', '.join(valid_send_on)}")
+            if hasattr(notifiers, "sendOnDryRun") and not isinstance(notifiers.sendOnDryRun, bool):
+                errors.append("notifiers.sendOnDryRun must be a boolean (true/false)")
 
         # Validate notifiers.telegram
         if "notifiers.telegram" in self._namespaces:
@@ -794,6 +803,16 @@ executionTimeout =
 # Possible values: true, false
 # Default: {DEFAULTS['notifiers']['enabled']}
 enabled =
+# When to send notifications
+# Possible values: changes, all
+#   changes - only on updates, failures, skips, errors, or warnings (recommended)
+#   all     - after every run with at least one container checked (legacy)
+# Default: {DEFAULTS['notifiers']['sendOn']}
+sendOn =
+# Send notifications for dry-run executions
+# Possible values: true, false
+# Default: {DEFAULTS['notifiers']['sendOnDryRun']}
+sendOnDryRun =
 
 [notifiers.telegram]
 # Enable Telegram notifications

--- a/app/utils/engines/__init__.py
+++ b/app/utils/engines/__init__.py
@@ -122,7 +122,7 @@ def recreate_container(client, container, image, container_inspect_data, dry_run
         new_version (str, optional): Image tag after the update
 
     Returns:
-        Container object if successful, None otherwise
+        Tuple of (container, error_message). On success: (container, None). On failure: (None, error_message).
     """
     engine = "docker"
 

--- a/app/utils/engines/docker.py
+++ b/app/utils/engines/docker.py
@@ -484,10 +484,20 @@ def pull_image(client, image_reference, dry_run):
             logging.debug(f"No credentials found for registry {registry}, attempting anonymous pull", extra={"indent": 6})
 
         logging.info(f"{'Would pull' if dry_run else 'Pulling'} image '{image_reference}'", extra={"indent": 4})
-        image = client.images.pull(image_reference) if not dry_run else None
-        if not dry_run and image:
+        if dry_run:
+            return None
+
+        for event in client.api.pull(image_reference, stream=True, decode=True):
+            if isinstance(event, dict) and event.get("error"):
+                raise docker_errors.APIError(event["error"])
+
+        image = client.images.get(image_reference)
+        if image:
             logging.debug(f"Successfully pulled image '{image.short_id}'", extra={"indent": 6})
         return image
+    except KeyboardInterrupt:
+        logging.warning(f"Image pull interrupted for '{image_reference}'", extra={"indent": 4})
+        raise
     except docker_errors.APIError as e:
         logging.error(f"Failed to pull image '{image_reference}': {str(e)}", extra={"indent": 6})
         return None
@@ -650,10 +660,21 @@ def verify_container_start(container, dry_run=False):
 
     logging.info( f"{'Would verify' if dry_run else 'Verifying'} startup of container '{container.name}'", extra={"indent": 4}, )
 
+    if dry_run:
+        if grace_period > 0:
+            logging.debug(
+                f"Would wait {grace_period}s before startup verification begins",
+                extra={"indent": 6},
+            )
+        logging.debug(
+            f"Would monitor container stability for up to {max_wait}s (check every {check_interval}s, stable for {stable_time}s)",
+            extra={"indent": 6},
+        )
+        return True
+
     if grace_period > 0:
-        logging.debug( f"{'Would wait' if dry_run else 'Waiting'} {grace_period}s before startup verification begins", extra={"indent": 6}, )
-        if not dry_run:
-            time.sleep(grace_period)
+        logging.debug( f"Waiting {grace_period}s before startup verification begins", extra={"indent": 6}, )
+        time.sleep(grace_period)
 
     stable_start = None
     container.reload()

--- a/app/utils/engines/docker.py
+++ b/app/utils/engines/docker.py
@@ -384,10 +384,10 @@ def get_local_image_metadata(image, container_inspect_data):
         imageUrl = f"{apiUrl}/repositories/{name}"
         imageTagsUrl = f"{apiUrl}/repositories/{name}/tags"
     else:
-        # e.g. 'ghcr.io/immich-app/immich-server'
+        # e.g. 'ghcr.io/immich-app/immich-server' or 'custom-registry.my-domain.com/org/app'
         registry = parts[0]
         name = "/".join(parts[1:])
-        apiUrl = config.ghcr.apiUrl
+        apiUrl = f"https://{registry}/v2"
         imageUrl = f"{apiUrl}/{name}"
         imageTagsUrl = f"{apiUrl}/{name}/tags/list"
 

--- a/app/utils/engines/docker.py
+++ b/app/utils/engines/docker.py
@@ -873,7 +873,7 @@ def recreate_container(client, container, image, container_inspect_data, dry_run
         new_version (str, optional): Image tag after the update
 
     Returns:
-        Container object if successful, None otherwise
+        Tuple of (container, error_message). On success: (container, None). On failure: (None, error_message).
     """
     original_name = container.name
     backup_name = get_container_backup_name(original_name)
@@ -960,7 +960,7 @@ def recreate_container(client, container, image, container_inspect_data, dry_run
             )
 
         rollback() if not dry_run else None
-        return None
+        return None, error_msg
 
     try:
         spec = get_container_spec(client, container_inspect_data, original_name, image, image_inspect_data)
@@ -979,23 +979,15 @@ def recreate_container(client, container, image, container_inspect_data, dry_run
             error_msg = f"Post-script failed for container '{original_name}'"
             logging.error(error_msg, extra={"indent": 4})
 
-            # Add error to notification manager if available
-            if notification_manager:
-                notification_manager.add_error(error_msg)
-
             if should_rollback_on_post_failure():
                 rollback()
-                return None
+                return None, error_msg
 
-        return new_container if not dry_run else container
+        return (new_container if not dry_run else container), None
 
     except Exception as e:
         error_msg = f"Failed to recreate new container: {e}"
         logging.error(error_msg, extra={"indent": 4})
-
-        # Add error to notification manager if available
-        if notification_manager:
-            notification_manager.add_error(error_msg)
 
         # Create comparison file for debugging
         if not dry_run:
@@ -1007,7 +999,7 @@ def recreate_container(client, container, image, container_inspect_data, dry_run
             )
 
         rollback() if not dry_run else None
-        return None
+        return None, error_msg
 
 
 def is_self_container(container_name, container_id):

--- a/app/utils/interrupt.py
+++ b/app/utils/interrupt.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Cooperative interrupt handling for long-running captn operations."""
+
+import signal
+import threading
+
+_interrupt_requested = threading.Event()
+
+
+def install_interrupt_handlers() -> None:
+    """Ensure SIGINT/SIGTERM raise KeyboardInterrupt in the main thread."""
+
+    def handler(signum, frame):
+        _interrupt_requested.set()
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+
+def check_interrupted() -> None:
+    """Raise KeyboardInterrupt when a shutdown signal was received."""
+    if _interrupt_requested.is_set():
+        raise KeyboardInterrupt

--- a/app/utils/notifiers/__init__.py
+++ b/app/utils/notifiers/__init__.py
@@ -22,6 +22,7 @@ class NotificationManager:
             "containers_failed": 0,
             "containers_skipped": 0,
             "update_details": [],
+            "skip_details": [],
             "errors": [],
             "warnings": [],
             "start_time": None,
@@ -97,8 +98,12 @@ class NotificationManager:
         """Increment the processed containers counter."""
         self.update_stats["containers_processed"] += 1
 
-    def increment_skipped(self):
-        """Increment the skipped containers counter."""
+    def add_skip_detail(self, container_name: str, reason: str):
+        """Record a skipped container and the reason it was not processed."""
+        self.update_stats["skip_details"].append({
+            "container_name": container_name,
+            "reason": reason,
+        })
         self.update_stats["containers_skipped"] += 1
 
     def set_start_time(self):
@@ -167,6 +172,7 @@ class NotificationManager:
             "containers_failed": 0,
             "containers_skipped": 0,
             "update_details": [],
+            "skip_details": [],
             "errors": [],
             "warnings": [],
             "start_time": None,

--- a/app/utils/notifiers/__init__.py
+++ b/app/utils/notifiers/__init__.py
@@ -23,7 +23,6 @@ class NotificationManager:
             "containers_skipped": 0,
             "update_details": [],
             "skip_details": [],
-            "errors": [],
             "warnings": [],
             "start_time": None,
             "end_time": None
@@ -70,25 +69,34 @@ class NotificationManager:
             elif email_config.enabled:
                 logging.warning("Email notifications enabled but smtpServer, fromAddr, or toAddr not configured")
 
-    def add_update_detail(self, container_name: str, old_version: str, new_version: str, update_type: str, duration: float = None, status: str = "succeeded"):
+    def add_update_detail(
+        self,
+        container_name: str,
+        old_version: str,
+        new_version: str,
+        update_type: str,
+        duration: float = None,
+        status: str = "succeeded",
+        error_message: str = None,
+    ):
         """Add an update to the statistics."""
-        self.update_stats["update_details"].append({
+        detail = {
             "container_name": container_name,
             "old_version": old_version,
             "new_version": new_version,
             "update_type": update_type,
             "duration": duration,
-            "status": status
-        })
+            "status": status,
+        }
+        if error_message:
+            detail["error_message"] = error_message
 
-        # Only increment containers_updated for successful updates
+        self.update_stats["update_details"].append(detail)
+
         if status == "succeeded":
             self.update_stats["containers_updated"] += 1
-
-    def add_error(self, error_message: str):
-        """Add an error to the statistics."""
-        self.update_stats["errors"].append(error_message)
-        self.update_stats["containers_failed"] += 1
+        elif status == "failed":
+            self.update_stats["containers_failed"] += 1
 
     def add_warning(self, warning_message: str):
         """Add a warning to the statistics."""
@@ -173,7 +181,6 @@ class NotificationManager:
             "containers_skipped": 0,
             "update_details": [],
             "skip_details": [],
-            "errors": [],
             "warnings": [],
             "start_time": None,
             "end_time": None

--- a/app/utils/notifiers/__init__.py
+++ b/app/utils/notifiers/__init__.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, List, Optional
 from .base import NotificationCollector
 from .telegram import TelegramNotifier
 from .smtp import SMTPNotifier
+from .report import should_send_notification
 from ..config import config
 from ..common import get_docker_host_hostname
 
@@ -108,6 +109,14 @@ class NotificationManager:
         """Set the end time of the update process."""
         self.update_stats["end_time"] = datetime.now()
 
+    def should_notify(self, dry_run: bool = False) -> bool:
+        """Return whether this run should trigger notifications."""
+        if not self.notifiers:
+            return False
+        if not hasattr(config, "notifiers"):
+            return False
+        return should_send_notification(self.update_stats, dry_run, config.notifiers)
+
     def send_update_report(self, dry_run: bool = False):
         """Send update report to all configured notifiers."""
         if not self.notifiers:
@@ -116,6 +125,15 @@ class NotificationManager:
 
         # Set end time before sending report
         self.set_end_time()
+
+        if not self.should_notify(dry_run):
+            send_on = getattr(config.notifiers, "sendOn", "changes")
+            logging.debug(
+                "Skipping notification: no noteworthy events (sendOn=%s, dry_run=%s)",
+                send_on,
+                dry_run,
+            )
+            return
 
         # Prepare update data
         update_data = {

--- a/app/utils/notifiers/report.py
+++ b/app/utils/notifiers/report.py
@@ -5,6 +5,19 @@ from typing import Any, Dict, List, Optional, Tuple
 
 StatusBanner = Tuple[str, str, str]  # (text, icon, hex_color)
 
+UPDATE_TYPE_EMOJI = {
+    "major": "🚀",
+    "minor": "✨",
+    "patch": "🐞",
+    "build": "🏗️",
+    "digest": "📦",
+}
+
+
+def update_type_emoji(update_type: str) -> str:
+    """Return the emoji symbol for an update type (shared by email and Telegram)."""
+    return UPDATE_TYPE_EMOJI.get(update_type, "⚪")
+
 
 def has_noteworthy_events(stats: Dict[str, Any]) -> bool:
     """Return True when the update run produced something worth notifying about."""

--- a/app/utils/notifiers/report.py
+++ b/app/utils/notifiers/report.py
@@ -1,0 +1,84 @@
+"""
+Shared notification report logic for all notifier channels.
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+StatusBanner = Tuple[str, str, str]  # (text, icon, hex_color)
+
+
+def has_noteworthy_events(stats: Dict[str, Any]) -> bool:
+    """Return True when the update run produced something worth notifying about."""
+    return (
+        stats.get("containers_updated", 0) > 0
+        or stats.get("containers_failed", 0) > 0
+        or stats.get("containers_skipped", 0) > 0
+        or bool(stats.get("errors"))
+        or bool(stats.get("warnings"))
+    )
+
+
+def resolve_status_banner(stats: Dict[str, Any]) -> Optional[StatusBanner]:
+    """
+    Determine the email status banner, or None to omit it.
+
+    When containers were checked but nothing was updated, failed, or skipped,
+    there is nothing meaningful to highlight in a banner.
+    """
+    failed = stats.get("containers_failed", 0)
+    updated = stats.get("containers_updated", 0)
+    skipped = stats.get("containers_skipped", 0)
+    processed = stats.get("containers_processed", 0)
+    errors = stats.get("errors", [])
+
+    if failed > 0 or errors:
+        return ("Issues Detected", "⚠️", "#dc3545")
+    if updated > 0:
+        return ("Updates Successful", "✅", "#28a745")
+    if skipped > 0:
+        return ("Containers Skipped", "⏭️", "#ffc107")
+    if processed > 0:
+        return None
+    return ("No Containers Checked", "ℹ️", "#6c757d")
+
+
+def should_send_notification(
+    stats: Dict[str, Any],
+    dry_run: bool,
+    notifiers_config: Any,
+) -> bool:
+    """
+    Decide whether to send notifications for this update run.
+
+    sendOn:
+      - changes (default): only when updates, failures, skips, errors, or warnings
+      - all: always when at least one container was checked (legacy behaviour)
+    """
+    send_on = getattr(notifiers_config, "sendOn", None) or "changes"
+    if isinstance(send_on, str):
+        send_on = send_on.strip().lower()
+
+    send_on_dry_run = getattr(notifiers_config, "sendOnDryRun", True)
+    if isinstance(send_on_dry_run, str):
+        send_on_dry_run = send_on_dry_run.strip().lower() == "true"
+
+    if dry_run and not send_on_dry_run:
+        return False
+
+    if send_on == "all":
+        if stats.get("containers_processed", 0) == 0 and not stats.get("errors"):
+            return False
+        return True
+
+    return has_noteworthy_events(stats)
+
+
+def format_duration(start_time, end_time) -> str:
+    """Format elapsed time between two datetimes as a human-readable string."""
+    if not start_time or not end_time:
+        return ""
+    total_duration = (end_time - start_time).total_seconds()
+    if total_duration < 60:
+        return f"{total_duration:.1f}s"
+    if total_duration < 3600:
+        return f"{total_duration / 60:.1f}m"
+    return f"{total_duration / 3600:.1f}h"

--- a/app/utils/notifiers/report.py
+++ b/app/utils/notifiers/report.py
@@ -25,7 +25,6 @@ def has_noteworthy_events(stats: Dict[str, Any]) -> bool:
         stats.get("containers_updated", 0) > 0
         or stats.get("containers_failed", 0) > 0
         or stats.get("containers_skipped", 0) > 0
-        or bool(stats.get("errors"))
         or bool(stats.get("warnings"))
     )
 
@@ -41,9 +40,7 @@ def resolve_status_banner(stats: Dict[str, Any]) -> Optional[StatusBanner]:
     updated = stats.get("containers_updated", 0)
     skipped = stats.get("containers_skipped", 0)
     processed = stats.get("containers_processed", 0)
-    errors = stats.get("errors", [])
-
-    if failed > 0 or errors:
+    if failed > 0:
         return ("Issues Detected", "⚠️", "#dc3545")
     if updated > 0:
         return ("Updates Successful", "✅", "#28a745")
@@ -78,7 +75,7 @@ def should_send_notification(
         return False
 
     if send_on == "all":
-        if stats.get("containers_processed", 0) == 0 and not stats.get("errors"):
+        if stats.get("containers_processed", 0) == 0 and stats.get("containers_failed", 0) == 0:
             return False
         return True
 

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -5,6 +5,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
 from .base import BaseNotifier
+from .report import resolve_status_banner, format_duration
 from typing import List, Dict, Any
 from datetime import datetime
 from app import __version__
@@ -189,38 +190,24 @@ class SMTPNotifier(BaseNotifier):
         else:
             timestamp_str = str(timestamp)
 
-        # Calculate duration
-        duration_str = ""
-        if start_time and end_time:
-            total_duration = (end_time - start_time).total_seconds()
-            if total_duration < 60:
-                duration_str = f"{total_duration:.1f}s"
-            elif total_duration < 3600:
-                duration_str = f"{total_duration / 60:.1f}m"
-            else:
-                duration_str = f"{total_duration / 3600:.1f}h"
+        duration_str = format_duration(start_time, end_time)
 
         # Separate successful and failed updates
         successful_updates = [detail for detail in update_details if detail.get("status") == "succeeded"]
         failed_updates = [detail for detail in update_details if detail.get("status") == "failed"]
 
-        # Determine overall status
-        if containers_failed > 0:
-            status_color = "#dc3545"  # Red
-            status_text = "Issues Detected"
-            status_icon = "⚠️"
-        elif containers_updated > 0:
-            status_color = "#28a745"  # Green
-            status_text = "Updates Successful"
-            status_icon = "✅"
-        elif containers_skipped > 0:
-            status_color = "#28a745"  # Green
-            status_text = "No Updates Needed"
-            status_icon = "✅"
+        stats = {
+            "containers_processed": containers_processed,
+            "containers_updated": containers_updated,
+            "containers_failed": containers_failed,
+            "containers_skipped": containers_skipped,
+            "errors": errors,
+        }
+        status_banner = resolve_status_banner(stats)
+        if status_banner:
+            status_text, status_icon, status_color = status_banner
         else:
-            status_color = "#6c757d"  # Gray
-            status_text = "No Containers Processed"
-            status_icon = "ℹ️"
+            status_text = status_icon = status_color = None
 
         # Build HTML content
         html = f"""
@@ -424,9 +411,7 @@ class SMTPNotifier(BaseNotifier):
             <p style="margin: 10px 0 0 0; opacity: 0.8;">{hostname} • {timestamp_str}</p>
         </div>
 
-        <div class="status-banner">
-            {status_icon} {status_text}
-        </div>
+        {self._generate_status_banner(status_icon, status_text, status_color)}
 
         <div class="content">
             {self._generate_dry_run_notice(dry_run)}
@@ -436,7 +421,7 @@ class SMTPNotifier(BaseNotifier):
                 <div class="summary">
                     <div class="stat-card">
                         <div class="stat-number">{containers_processed}</div>
-                        <div class="stat-label">Processed</div>
+                        <div class="stat-label">Checked</div>
                     </div>
                     <div class="stat-card">
                         <div class="stat-number" style="color: #28a745;">{containers_updated}</div>
@@ -471,6 +456,16 @@ class SMTPNotifier(BaseNotifier):
 """
 
         return html
+
+    def _generate_status_banner(self, status_icon: str, status_text: str, status_color: str) -> str:
+        """Generate status banner HTML, or empty string when omitted."""
+        if not status_text:
+            return ""
+        return f"""
+        <div class="status-banner">
+            {status_icon} {status_text}
+        </div>
+        """
 
     def _generate_dry_run_notice(self, dry_run: bool) -> str:
         """Generate dry run notice if applicable."""

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -12,6 +12,7 @@ from app import __version__
 
 CAPTN_PRIMARY = "#0066cc"
 CAPTN_ACCENT = "#0db7ed"
+CAPTN_HEADER_BG = "#f0f8fc"
 
 _MAIL_ICONS = {
     "summary": (
@@ -32,9 +33,11 @@ _MAIL_ICONS = {
         '<path d="M6 6l4 4M10 6l-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
     ),
     "skip": (
+        '<g transform="matrix(-1 0 0 -1 16 16)">'
         '<path d="M3 4h7a3 3 0 0 1 0 6H6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
         '<path d="M6 7L3 4l3-3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
         '<path d="M11 10h2v4h-2" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>'
+        '</g>'
     ),
     "alert": (
         '<path d="M8 2.5L14 13.5H2L8 2.5z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
@@ -312,11 +315,11 @@ class SMTPNotifier(BaseNotifier):
             overflow: hidden;
         }}
         .header {{
-            background: #ffffff;
+            background: {CAPTN_HEADER_BG};
             color: #212529;
             padding: 30px;
             text-align: center;
-            border-bottom: 1px solid #dee2e6;
+            border-bottom: 1px solid #c5e0f5;
         }}
         .logo {{
             width: 48px;

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -495,18 +495,14 @@ class SMTPNotifier(BaseNotifier):
         # Successful updates
         if successful_updates:
             html += '<h3 style="color: #28a745; margin-bottom: 15px;">✅ Successful Updates</h3>'
-            for detail in successful_updates[:20]:  # Limit to first 20
+            for detail in successful_updates:
                 html += self._format_update_item(detail, "success")
-            if len(successful_updates) > 20:
-                html += f'<p style="text-align: center; color: #6c757d; font-style: italic;">... and {len(successful_updates) - 20} more successful updates</p>'
 
         # Failed updates
         if failed_updates:
             html += '<h3 style="color: #dc3545; margin: 30px 0 15px 0;">❌ Failed Updates</h3>'
-            for detail in failed_updates[:10]:  # Limit to first 10
+            for detail in failed_updates:
                 html += self._format_update_item(detail, "failed")
-            if len(failed_updates) > 10:
-                html += f'<p style="text-align: center; color: #6c757d; font-style: italic;">... and {len(failed_updates) - 10} more failed updates</p>'
 
         html += '</div>'
         return html
@@ -556,11 +552,8 @@ class SMTPNotifier(BaseNotifier):
             return ""
 
         error_items = ""
-        for error in errors[:10]:  # Limit to first 10 errors
+        for error in errors:
             error_items += f'<div class="error-item">• {error}</div>'
-
-        if len(errors) > 10:
-            error_items += f'<div class="error-item" style="font-style: italic; color: #6c757d;">... and {len(errors) - 10} more errors</div>'
 
         return f"""
         <div class="section">
@@ -577,11 +570,8 @@ class SMTPNotifier(BaseNotifier):
             return ""
 
         warning_items = ""
-        for warning in warnings[:5]:  # Limit to first 5 warnings
+        for warning in warnings:
             warning_items += f'<div class="warning-item">• {warning}</div>'
-
-        if len(warnings) > 5:
-            warning_items += f'<div class="warning-item" style="font-style: italic; color: #6c757d;">... and {len(warnings) - 5} more warnings</div>'
 
         return f"""
         <div class="section">

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -179,6 +179,7 @@ class SMTPNotifier(BaseNotifier):
         containers_failed = update_data.get("containers_failed", 0)
         containers_skipped = update_data.get("containers_skipped", 0)
         update_details = update_data.get("update_details", [])
+        skip_details = update_data.get("skip_details", [])
         errors = update_data.get("errors", [])
         warnings = update_data.get("warnings", [])
         start_time = update_data.get("start_time")
@@ -440,6 +441,7 @@ class SMTPNotifier(BaseNotifier):
             </div>
 
             {self._generate_updates_section(successful_updates, failed_updates)}
+            {self._generate_skipped_section(skip_details)}
             {self._generate_errors_section(errors)}
             {self._generate_warnings_section(warnings)}
         </div>
@@ -506,6 +508,29 @@ class SMTPNotifier(BaseNotifier):
 
         html += '</div>'
         return html
+
+    def _generate_skipped_section(self, skip_details: List[Dict]) -> str:
+        """Generate skipped containers section if there are any."""
+        if not skip_details:
+            return ""
+
+        items = ""
+        for detail in skip_details:
+            container_name = detail.get("container_name", "Unknown")
+            reason = detail.get("reason", "Unknown")
+            items += f"""
+        <div class="update-item skipped">
+            <div class="container-name">{container_name}</div>
+            <div class="version-info">{reason}</div>
+        </div>
+        """
+
+        return f"""
+        <div class="section">
+            <h2>⏭️ Skipped Containers</h2>
+            {items}
+        </div>
+        """
 
     def _format_update_item(self, detail: Dict, status: str) -> str:
         """Format a single update item."""

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -10,6 +10,83 @@ from typing import List, Dict, Any
 from datetime import datetime
 from app import __version__
 
+CAPTN_PRIMARY = "#0066cc"
+CAPTN_ACCENT = "#0db7ed"
+
+_MAIL_ICONS = {
+    "summary": (
+        '<rect x="2" y="9" width="3" height="5" rx="0.5" fill="currentColor"/>'
+        '<rect x="6.5" y="5" width="3" height="9" rx="0.5" fill="currentColor"/>'
+        '<rect x="11" y="2" width="3" height="12" rx="0.5" fill="currentColor"/>'
+    ),
+    "package": (
+        '<path d="M2 5l6-3 6 3v6l-6 3-6-3V5z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
+        '<path d="M8 8v6M2 5l6 3 6-3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
+    ),
+    "check-circle": (
+        '<circle cx="8" cy="8" r="6.25" stroke="currentColor" stroke-width="1.5" fill="none"/>'
+        '<path d="M5.5 8l1.75 1.75L10.5 6.25" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
+    ),
+    "x-circle": (
+        '<circle cx="8" cy="8" r="6.25" stroke="currentColor" stroke-width="1.5" fill="none"/>'
+        '<path d="M6 6l4 4M10 6l-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
+    ),
+    "skip": (
+        '<path d="M3 4h7a3 3 0 0 1 0 6H6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
+        '<path d="M6 7L3 4l3-3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
+        '<path d="M11 10h2v4h-2" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>'
+    ),
+    "alert": (
+        '<path d="M8 2.5L14 13.5H2L8 2.5z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
+        '<path d="M8 6.5v3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
+        '<circle cx="8" cy="11.75" r="0.75" fill="currentColor"/>'
+    ),
+    "info": (
+        '<circle cx="8" cy="8" r="6.25" stroke="currentColor" stroke-width="1.5" fill="none"/>'
+        '<path d="M8 7v4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
+        '<circle cx="8" cy="5.25" r="0.75" fill="currentColor"/>'
+    ),
+    "clock": (
+        '<circle cx="8" cy="8" r="6.25" stroke="currentColor" stroke-width="1.5" fill="none"/>'
+        '<path d="M8 4.5V8l2.5 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>'
+    ),
+    "test": (
+        '<path d="M5.5 3.5h5l1 3H4.5l1-3z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
+        '<path d="M4.5 6.5h7v5a1.5 1.5 0 0 1-1.5 1.5H6a1.5 1.5 0 0 1-1.5-1.5v-5z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
+        '<path d="M6.5 9.5h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
+    ),
+}
+
+_STATUS_ICON_KEY = {
+    "Issues Detected": "alert",
+    "Updates Successful": "check-circle",
+    "Containers Skipped": "skip",
+    "No Containers Checked": "info",
+}
+
+
+def _mail_icon(name: str, size: int = 16) -> str:
+    """Render a monotone inline SVG icon for HTML email."""
+    paths = _MAIL_ICONS.get(name)
+    if not paths:
+        return ""
+    return (
+        f'<span class="mail-icon" style="display:inline-block;vertical-align:-2px;margin-right:6px;line-height:0;">'
+        f'<svg width="{size}" height="{size}" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">'
+        f"{paths}</svg></span>"
+    )
+
+
+def _section_heading(level: int, icon: str, title: str, color: str = None, extra_style: str = None) -> str:
+    tag = f"h{level}"
+    styles = []
+    if color:
+        styles.append(f"color: {color}")
+    if extra_style:
+        styles.append(extra_style)
+    style_attr = f' style="{"; ".join(styles)}"' if styles else ""
+    return f"<{tag}{style_attr}>{_mail_icon(icon)}{title}</{tag}>"
+
 
 class SMTPNotifier(BaseNotifier):
     """
@@ -235,10 +312,11 @@ class SMTPNotifier(BaseNotifier):
             overflow: hidden;
         }}
         .header {{
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
+            background: #ffffff;
+            color: #212529;
             padding: 30px;
             text-align: center;
+            border-bottom: 1px solid #dee2e6;
         }}
         .logo {{
             width: 48px;
@@ -249,11 +327,17 @@ class SMTPNotifier(BaseNotifier):
             margin: 0;
             font-size: 28px;
             font-weight: 600;
+            color: #212529;
         }}
         .header .subtitle {{
             margin: 5px 0 0 0;
             font-size: 16px;
-            opacity: 0.9;
+            color: #495057;
+        }}
+        .header .meta {{
+            margin: 10px 0 0 0;
+            font-size: 14px;
+            color: #6c757d;
         }}
         .status-banner {{
             background: {status_color};
@@ -277,12 +361,12 @@ class SMTPNotifier(BaseNotifier):
             border-radius: 8px;
             padding: 20px;
             text-align: center;
-            border-left: 4px solid #667eea;
+            border-left: 4px solid {CAPTN_PRIMARY};
         }}
         .stat-number {{
             font-size: 32px;
             font-weight: 700;
-            color: #667eea;
+            color: {CAPTN_PRIMARY};
             margin: 0;
         }}
         .stat-label {{
@@ -301,6 +385,24 @@ class SMTPNotifier(BaseNotifier):
             padding-bottom: 10px;
             margin-bottom: 20px;
             font-size: 20px;
+        }}
+        .section h3 {{
+            color: #495057;
+            font-size: 16px;
+            margin-bottom: 15px;
+        }}
+        .mail-icon {{
+            color: inherit;
+        }}
+        .list-marker {{
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            background: currentColor;
+            border-radius: 1px;
+            margin-right: 10px;
+            vertical-align: middle;
+            opacity: 0.55;
         }}
         .update-item {{
             background: #f8f9fa;
@@ -339,7 +441,7 @@ class SMTPNotifier(BaseNotifier):
             color: #6c757d;
         }}
         .update-type {{
-            background: #667eea;
+            background: {CAPTN_PRIMARY};
             color: white;
             padding: 2px 8px;
             border-radius: 12px;
@@ -350,7 +452,7 @@ class SMTPNotifier(BaseNotifier):
         .update-type.minor {{ background: #fd7e14; }}
         .update-type.patch {{ background: #28a745; }}
         .update-type.build {{ background: #17a2b8; }}
-        .update-type.digest {{ background: #6f42c1; }}
+        .update-type.digest {{ background: {CAPTN_ACCENT}; }}
         .error-list, .warning-list {{
             background: #fff5f5;
             border: 1px solid #f5c6cb;
@@ -378,13 +480,13 @@ class SMTPNotifier(BaseNotifier):
             border-top: 1px solid #e9ecef;
         }}
         .dry-run-notice {{
-            background: #e3f2fd;
-            border: 1px solid #bbdefb;
+            background: #e6f4fc;
+            border: 1px solid #99d6f5;
             border-radius: 6px;
             padding: 15px;
             margin: 20px 0;
             text-align: center;
-            color: #1976d2;
+            color: {CAPTN_PRIMARY};
         }}
         .no-updates {{
             text-align: center;
@@ -409,7 +511,7 @@ class SMTPNotifier(BaseNotifier):
             <img src="cid:logo" alt="captn Logo" class="logo" onerror="this.style.display='none'">
             <h1>captn</h1>
             <p class="subtitle">Container Update Report</p>
-            <p style="margin: 10px 0 0 0; opacity: 0.8;">{hostname} • {timestamp_str}</p>
+            <p class="meta">{hostname} • {timestamp_str}</p>
         </div>
 
         {self._generate_status_banner(status_icon, status_text, status_color)}
@@ -418,7 +520,7 @@ class SMTPNotifier(BaseNotifier):
             {self._generate_dry_run_notice(dry_run)}
 
             <div class="section">
-                <h2>📊 Summary</h2>
+                <h2>{_mail_icon("summary")}Summary</h2>
                 <div class="summary">
                     <div class="stat-card">
                         <div class="stat-number">{containers_processed}</div>
@@ -461,20 +563,22 @@ class SMTPNotifier(BaseNotifier):
 
     def _generate_status_banner(self, status_icon: str, status_text: str, status_color: str) -> str:
         """Generate status banner HTML, or empty string when omitted."""
+        del status_icon  # email uses monotone SVG icons, not shared emoji labels
         if not status_text:
             return ""
+        icon_key = _STATUS_ICON_KEY.get(status_text, "info")
         return f"""
         <div class="status-banner">
-            {status_icon} {status_text}
+            {_mail_icon(icon_key, size=18)}{status_text}
         </div>
         """
 
     def _generate_dry_run_notice(self, dry_run: bool) -> str:
         """Generate dry run notice if applicable."""
         if dry_run:
-            return """
+            return f"""
             <div class="dry-run-notice">
-                <strong>🩺 DRY RUN MODE</strong><br>
+                <strong>{_mail_icon("test")}DRY RUN MODE</strong><br>
                 This was a test run - no actual changes were made to containers.
             </div>
             """
@@ -483,26 +587,26 @@ class SMTPNotifier(BaseNotifier):
     def _generate_updates_section(self, successful_updates: List[Dict], failed_updates: List[Dict]) -> str:
         """Generate the updates section with successful and failed updates."""
         if not successful_updates and not failed_updates:
-            return """
+            return f"""
             <div class="section">
-                <h2>📦 Container Updates</h2>
+                <h2>{_mail_icon("package")}Container Updates</h2>
                 <div class="no-updates">
                     No container updates were performed.
                 </div>
             </div>
             """
 
-        html = '<div class="section"><h2>📦 Container Updates</h2>'
+        html = f'<div class="section"><h2>{_mail_icon("package")}Container Updates</h2>'
 
         # Successful updates
         if successful_updates:
-            html += '<h3 style="color: #28a745; margin-bottom: 15px;">✅ Successful Updates</h3>'
+            html += _section_heading(3, "check-circle", "Successful Updates", "#28a745")
             for detail in successful_updates:
                 html += self._format_update_item(detail, "success")
 
         # Failed updates
         if failed_updates:
-            html += '<h3 style="color: #dc3545; margin: 30px 0 15px 0;">❌ Failed Updates</h3>'
+            html += _section_heading(3, "x-circle", "Failed Updates", "#dc3545", "margin: 30px 0 15px 0")
             for detail in failed_updates:
                 html += self._format_update_item(detail, "failed")
 
@@ -527,7 +631,7 @@ class SMTPNotifier(BaseNotifier):
 
         return f"""
         <div class="section">
-            <h2>⏭️ Skipped Containers</h2>
+            <h2>{_mail_icon("skip")}Skipped Containers</h2>
             {items}
         </div>
         """
@@ -551,22 +655,13 @@ class SMTPNotifier(BaseNotifier):
         else:
             duration_str = "N/A"
 
-        # Get update type emoji and class
-        type_emoji = {
-            "major": "🚀",
-            "minor": "✨",
-            "patch": "🐞",
-            "build": "🏗️",
-            "digest": "📦"
-        }.get(update_type, "⚪")
-
         return f"""
         <div class="update-item {'failed' if status == 'failed' else ''}">
             <div class="container-name">{container_name}</div>
             <div class="version-info">{old_version} → {new_version}</div>
             <div class="update-meta">
-                <span class="update-type {update_type}">{type_emoji} {update_type}</span>
-                <span>⏱️ {duration_str}</span>
+                <span class="update-type {update_type}">{update_type}</span>
+                <span>{_mail_icon("clock", size=14)}{duration_str}</span>
             </div>
         </div>
         """
@@ -578,11 +673,11 @@ class SMTPNotifier(BaseNotifier):
 
         error_items = ""
         for error in errors:
-            error_items += f'<div class="error-item">• {error}</div>'
+            error_items += f'<div class="error-item"><span class="list-marker"></span>{error}</div>'
 
         return f"""
         <div class="section">
-            <h2>❌ Errors</h2>
+            <h2>{_mail_icon("x-circle")}Errors</h2>
             <div class="error-list">
                 {error_items}
             </div>
@@ -596,11 +691,11 @@ class SMTPNotifier(BaseNotifier):
 
         warning_items = ""
         for warning in warnings:
-            warning_items += f'<div class="warning-item">• {warning}</div>'
+            warning_items += f'<div class="warning-item"><span class="list-marker"></span>{warning}</div>'
 
         return f"""
         <div class="section">
-            <h2>⚠️ Warnings</h2>
+            <h2>{_mail_icon("alert")}Warnings</h2>
             <div class="warning-list">
                 {warning_items}
             </div>

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -325,7 +325,7 @@ class SMTPNotifier(BaseNotifier):
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>captn v{__version__} Update Report - {hostname}</title>
+    <title>captn Update Report - {hostname}</title>
     <style>
         body {{
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -12,7 +12,28 @@ from app import __version__
 
 CAPTN_PRIMARY = "#0066cc"
 CAPTN_ACCENT = "#0db7ed"
-CAPTN_HEADER_BG = "#f0f8fc"
+
+
+def _muted_status_background(hex_color: str, mix: float = 0.1) -> str:
+    """Blend a status color with white for subtle header backgrounds."""
+    color = hex_color.lstrip("#")
+    red = int(color[0:2], 16)
+    green = int(color[2:4], 16)
+    blue = int(color[4:6], 16)
+    red = int(red * mix + 255 * (1 - mix))
+    green = int(green * mix + 255 * (1 - mix))
+    blue = int(blue * mix + 255 * (1 - mix))
+    return f"#{red:02x}{green:02x}{blue:02x}"
+
+
+def _header_edge_gradients(light: str, dark: str) -> str:
+    """Layer short edge vignettes from all sides; bottom is slightly stronger."""
+    return (
+        f"linear-gradient(to top, {dark} 0%, transparent 22%), "
+        f"linear-gradient(to bottom, {dark} 0%, transparent 18%), "
+        f"linear-gradient(to right, {dark} 0%, transparent 14%), "
+        f"linear-gradient(to left, {dark} 0%, transparent 14%)"
+    )
 
 _MAIL_ICONS = {
     "summary": (
@@ -290,6 +311,13 @@ class SMTPNotifier(BaseNotifier):
         else:
             status_text = status_icon = status_color = None
 
+        header_status_color = status_color or CAPTN_PRIMARY
+        header_bg_light = _muted_status_background(header_status_color, mix=0.08)
+        header_bg_dark = _muted_status_background(header_status_color, mix=0.2)
+        header_border = _muted_status_background(header_status_color, mix=0.22)
+        header_background_image = _header_edge_gradients(header_bg_light, header_bg_dark)
+        header_border_css = "" if status_text else f"border-bottom: 1px solid {header_border};"
+
         # Build HTML content
         html = f"""
 <!DOCTYPE html>
@@ -315,11 +343,12 @@ class SMTPNotifier(BaseNotifier):
             overflow: hidden;
         }}
         .header {{
-            background: {CAPTN_HEADER_BG};
+            background-color: {header_bg_light};
+            background-image: {header_background_image};
             color: #212529;
             padding: 30px;
             text-align: center;
-            border-bottom: 1px solid #c5e0f5;
+            {header_border_css}
         }}
         .logo {{
             width: 48px;

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -348,11 +348,6 @@ class SMTPNotifier(BaseNotifier):
             text-align: center;
             {header_border_css}
         }}
-        .logo {{
-            width: 48px;
-            height: 48px;
-            margin-bottom: 15px;
-        }}
         .header h1 {{
             margin: 0;
             font-size: 28px;
@@ -538,7 +533,15 @@ class SMTPNotifier(BaseNotifier):
 <body>
     <div class="container">
         <div class="header">
-            <img src="cid:logo" alt="captn Logo" class="logo" onerror="this.style.display='none'">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse;">
+                <tr>
+                    <td align="center" style="padding:0 0 15px 0;">
+                        <img src="cid:logo" width="48" height="48" alt="captn Logo"
+                             style="display:block;width:48px;height:48px;max-width:48px;margin:0 auto;border:0;outline:none;-ms-interpolation-mode:bicubic;"
+                             onerror="this.style.display='none'">
+                    </td>
+                </tr>
+            </table>
             <h1>captn</h1>
             <p class="subtitle">Container Update Report</p>
             <p class="meta">{hostname} • {timestamp_str}</p>

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -5,7 +5,7 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.image import MIMEImage
 from .base import BaseNotifier
-from .report import resolve_status_banner, format_duration
+from .report import resolve_status_banner, format_duration, update_type_emoji
 from typing import List, Dict, Any
 from datetime import datetime
 from app import __version__
@@ -54,11 +54,9 @@ _MAIL_ICONS = {
         '<path d="M6 6l4 4M10 6l-4 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
     ),
     "skip": (
-        '<g transform="matrix(-1 0 0 -1 16 16)">'
-        '<path d="M3 4h7a3 3 0 0 1 0 6H6" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
-        '<path d="M6 7L3 4l3-3" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>'
-        '<path d="M11 10h2v4h-2" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>'
-        '</g>'
+        '<path d="M3.25 4.5v7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
+        '<path d="M6 4.5v7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>'
+        '<path d="M9.25 5l4 3-4 3V5z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
     ),
     "alert": (
         '<path d="M8 2.5L14 13.5H2L8 2.5z" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linejoin="round"/>'
@@ -692,7 +690,7 @@ class SMTPNotifier(BaseNotifier):
             <div class="container-name">{container_name}</div>
             <div class="version-info">{old_version} → {new_version}</div>
             <div class="update-meta">
-                <span class="update-type {update_type}">{update_type}</span>
+                <span class="update-type {update_type}">{update_type_emoji(update_type)} {update_type}</span>
                 <span>{_mail_icon("clock", size=14)}{duration_str}</span>
             </div>
         </div>

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -498,6 +498,16 @@ class SMTPNotifier(BaseNotifier):
             background: #d4f1fc;
             color: #0a8fbd;
         }}
+        .update-duration {{
+            display: inline-block;
+            background: #e9ecef;
+            color: #6c757d;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 500;
+            line-height: 1.3;
+        }}
         .error-list, .warning-list {{
             background: #fff5f5;
             border: 1px solid #f5c6cb;
@@ -714,7 +724,7 @@ class SMTPNotifier(BaseNotifier):
                 <tr>
                     <td><span class="update-type {update_type}">{update_type_emoji(update_type)} {update_type}</span></td>
                     <td><span class="update-type {update_type} update-step">{old_version} → {new_version}</span></td>
-                    <td>{_mail_icon("clock", size=14)}{duration_str}</td>
+                    <td><span class="update-duration">{_mail_icon("clock", size=14)}{duration_str}</span></td>
                 </tr>
             </table>
         </div>

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -26,15 +26,6 @@ def _muted_status_background(hex_color: str, mix: float = 0.1) -> str:
     return f"#{red:02x}{green:02x}{blue:02x}"
 
 
-def _header_edge_gradients(light: str, dark: str) -> str:
-    """Layer short edge vignettes from all sides; bottom is slightly stronger."""
-    return (
-        f"linear-gradient(to top, {dark} 0%, transparent 22%), "
-        f"linear-gradient(to bottom, {dark} 0%, transparent 18%), "
-        f"linear-gradient(to right, {dark} 0%, transparent 14%), "
-        f"linear-gradient(to left, {dark} 0%, transparent 14%)"
-    )
-
 _MAIL_ICONS = {
     "summary": (
         '<rect x="2" y="9" width="3" height="5" rx="0.5" fill="currentColor"/>'
@@ -262,7 +253,6 @@ class SMTPNotifier(BaseNotifier):
                 - containers_failed: int
                 - containers_skipped: int
                 - update_details: List[Dict] with container update details
-                - errors: List[str] (optional)
                 - warnings: List[str] (optional)
                 - start_time: datetime (optional)
                 - end_time: datetime (optional)
@@ -279,7 +269,6 @@ class SMTPNotifier(BaseNotifier):
         containers_skipped = update_data.get("containers_skipped", 0)
         update_details = update_data.get("update_details", [])
         skip_details = update_data.get("skip_details", [])
-        errors = update_data.get("errors", [])
         warnings = update_data.get("warnings", [])
         start_time = update_data.get("start_time")
         end_time = update_data.get("end_time")
@@ -301,7 +290,6 @@ class SMTPNotifier(BaseNotifier):
             "containers_updated": containers_updated,
             "containers_failed": containers_failed,
             "containers_skipped": containers_skipped,
-            "errors": errors,
         }
         status_banner = resolve_status_banner(stats)
         if status_banner:
@@ -310,10 +298,8 @@ class SMTPNotifier(BaseNotifier):
             status_text = status_icon = status_color = None
 
         header_status_color = status_color or CAPTN_PRIMARY
-        header_bg_light = _muted_status_background(header_status_color, mix=0.08)
-        header_bg_dark = _muted_status_background(header_status_color, mix=0.2)
+        header_bg = _muted_status_background(header_status_color, mix=0.1)
         header_border = _muted_status_background(header_status_color, mix=0.22)
-        header_background_image = _header_edge_gradients(header_bg_light, header_bg_dark)
         header_border_css = "" if status_text else f"border-bottom: 1px solid {header_border};"
 
         # Build HTML content
@@ -341,8 +327,7 @@ class SMTPNotifier(BaseNotifier):
             overflow: hidden;
         }}
         .header {{
-            background-color: {header_bg_light};
-            background-image: {header_background_image};
+            background-color: {header_bg};
             color: #212529;
             padding: 30px;
             text-align: center;
@@ -451,33 +436,68 @@ class SMTPNotifier(BaseNotifier):
             margin-bottom: 5px;
         }}
         .version-info {{
-            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-            background: #e9ecef;
+            font-size: 13px;
+            color: #495057;
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
             padding: 8px 12px;
-            border-radius: 4px;
-            margin: 5px 0;
-            font-size: 14px;
+            border-radius: 6px;
+            margin: 6px 0;
+            line-height: 1.5;
         }}
         .update-meta {{
-            display: flex;
-            gap: 15px;
             margin-top: 8px;
+            border-collapse: collapse;
+        }}
+        .update-meta td {{
+            padding: 0 8px 0 0;
+            vertical-align: middle;
             font-size: 14px;
             color: #6c757d;
+            white-space: nowrap;
+        }}
+        .update-meta td:last-child {{
+            padding-right: 0;
         }}
         .update-type {{
+            display: inline-block;
             background: {CAPTN_PRIMARY};
             color: white;
-            padding: 2px 8px;
+            padding: 4px 10px;
             border-radius: 12px;
             font-size: 12px;
-            font-weight: 500;
+            font-weight: 600;
+            line-height: 1.3;
         }}
         .update-type.major {{ background: #dc3545; }}
         .update-type.minor {{ background: #fd7e14; }}
         .update-type.patch {{ background: #28a745; }}
         .update-type.build {{ background: #17a2b8; }}
         .update-type.digest {{ background: {CAPTN_ACCENT}; }}
+        .update-type.update-step {{
+            background: #d6ebfa;
+            color: #0056ad;
+        }}
+        .update-type.major.update-step {{
+            background: #f8d7da;
+            color: #b02a37;
+        }}
+        .update-type.minor.update-step {{
+            background: #ffe8d4;
+            color: #c85c00;
+        }}
+        .update-type.patch.update-step {{
+            background: #d4edda;
+            color: #1e7e34;
+        }}
+        .update-type.build.update-step {{
+            background: #d1ecf1;
+            color: #117a8b;
+        }}
+        .update-type.digest.update-step {{
+            background: #d4f1fc;
+            color: #0a8fbd;
+        }}
         .error-list, .warning-list {{
             background: #fff5f5;
             border: 1px solid #f5c6cb;
@@ -522,10 +542,6 @@ class SMTPNotifier(BaseNotifier):
         @media (max-width: 600px) {{
             .summary {{
                 grid-template-columns: repeat(2, 1fr);
-            }}
-            .update-meta {{
-                flex-direction: column;
-                gap: 5px;
             }}
         }}
     </style>
@@ -577,7 +593,6 @@ class SMTPNotifier(BaseNotifier):
 
             {self._generate_updates_section(successful_updates, failed_updates)}
             {self._generate_skipped_section(skip_details)}
-            {self._generate_errors_section(errors)}
             {self._generate_warnings_section(warnings)}
         </div>
 
@@ -688,32 +703,20 @@ class SMTPNotifier(BaseNotifier):
         else:
             duration_str = "N/A"
 
+        error_message = detail.get("error_message")
+        error_html = f'<div class="version-info">{error_message}</div>' if error_message else ""
+
         return f"""
         <div class="update-item {'failed' if status == 'failed' else ''}">
             <div class="container-name">{container_name}</div>
-            <div class="version-info">{old_version} → {new_version}</div>
-            <div class="update-meta">
-                <span class="update-type {update_type}">{update_type_emoji(update_type)} {update_type}</span>
-                <span>{_mail_icon("clock", size=14)}{duration_str}</span>
-            </div>
-        </div>
-        """
-
-    def _generate_errors_section(self, errors: List[str]) -> str:
-        """Generate errors section if there are any."""
-        if not errors:
-            return ""
-
-        error_items = ""
-        for error in errors:
-            error_items += f'<div class="error-item"><span class="list-marker"></span>{error}</div>'
-
-        return f"""
-        <div class="section">
-            <h2>{_mail_icon("x-circle")}Errors</h2>
-            <div class="error-list">
-                {error_items}
-            </div>
+            {error_html}
+            <table role="presentation" class="update-meta" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    <td><span class="update-type {update_type}">{update_type_emoji(update_type)} {update_type}</span></td>
+                    <td><span class="update-type {update_type} update-step">{old_version} → {new_version}</span></td>
+                    <td>{_mail_icon("clock", size=14)}{duration_str}</td>
+                </tr>
+            </table>
         </div>
         """
 

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -407,7 +407,7 @@ class SMTPNotifier(BaseNotifier):
     <div class="container">
         <div class="header">
             <img src="cid:logo" alt="captn Logo" class="logo" onerror="this.style.display='none'">
-            <h1>captn v{__version__}</h1>
+            <h1>captn</h1>
             <p class="subtitle">Container Update Report</p>
             <p style="margin: 10px 0 0 0; opacity: 0.8;">{hostname} • {timestamp_str}</p>
         </div>

--- a/app/utils/notifiers/smtp.py
+++ b/app/utils/notifiers/smtp.py
@@ -420,6 +420,8 @@ class SMTPNotifier(BaseNotifier):
             padding: 15px;
             margin-bottom: 10px;
             border-left: 4px solid #28a745;
+            max-width: 100%;
+            overflow-wrap: anywhere;
         }}
         .update-item.failed {{
             border-left-color: #dc3545;
@@ -447,17 +449,7 @@ class SMTPNotifier(BaseNotifier):
         }}
         .update-meta {{
             margin-top: 8px;
-            border-collapse: collapse;
-        }}
-        .update-meta td {{
-            padding: 0 8px 0 0;
-            vertical-align: middle;
-            font-size: 14px;
-            color: #6c757d;
-            white-space: nowrap;
-        }}
-        .update-meta td:last-child {{
-            padding-right: 0;
+            line-height: 1.6;
         }}
         .update-type {{
             display: inline-block;
@@ -467,7 +459,14 @@ class SMTPNotifier(BaseNotifier):
             border-radius: 12px;
             font-size: 12px;
             font-weight: 600;
-            line-height: 1.3;
+            line-height: 1.4;
+            white-space: normal;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+            max-width: 100%;
+            margin: 0 8px 6px 0;
+            vertical-align: top;
+            box-sizing: border-box;
         }}
         .update-type.major {{ background: #dc3545; }}
         .update-type.minor {{ background: #fd7e14; }}
@@ -506,7 +505,14 @@ class SMTPNotifier(BaseNotifier):
             border-radius: 12px;
             font-size: 12px;
             font-weight: 500;
-            line-height: 1.3;
+            line-height: 1.4;
+            white-space: normal;
+            word-break: break-word;
+            overflow-wrap: anywhere;
+            max-width: 100%;
+            margin: 0 8px 6px 0;
+            vertical-align: top;
+            box-sizing: border-box;
         }}
         .error-list, .warning-list {{
             background: #fff5f5;
@@ -720,13 +726,11 @@ class SMTPNotifier(BaseNotifier):
         <div class="update-item {'failed' if status == 'failed' else ''}">
             <div class="container-name">{container_name}</div>
             {error_html}
-            <table role="presentation" class="update-meta" cellpadding="0" cellspacing="0" border="0">
-                <tr>
-                    <td><span class="update-type {update_type}">{update_type_emoji(update_type)} {update_type}</span></td>
-                    <td><span class="update-type {update_type} update-step">{old_version} → {new_version}</span></td>
-                    <td><span class="update-duration">{_mail_icon("clock", size=14)}{duration_str}</span></td>
-                </tr>
-            </table>
+            <div class="update-meta">
+                <span class="update-type {update_type}">{update_type_emoji(update_type)} {update_type}</span>
+                <span class="update-type {update_type} update-step">{old_version} → {new_version}</span>
+                <span class="update-duration">{_mail_icon("clock", size=14)}{duration_str}</span>
+            </div>
         </div>
         """
 

--- a/app/utils/notifiers/telegram.py
+++ b/app/utils/notifiers/telegram.py
@@ -3,6 +3,7 @@ import logging
 import json
 import os
 from .base import BaseNotifier
+from .report import format_duration
 from typing import List, Dict, Any
 from datetime import datetime
 
@@ -325,20 +326,13 @@ class TelegramNotifier(BaseNotifier):
 
         # Summary
         lines.append("<b>📊 Summary:</b>")
-        lines.append(f"• Processed: {containers_processed}")
+        lines.append(f"• Checked: {containers_processed}")
         lines.append(f"• Updated: {containers_updated}")
         lines.append(f"• Failed: {containers_failed}")
         lines.append(f"• Skipped: {containers_skipped}")
 
-        # Add total duration if available
-        if start_time and end_time:
-            total_duration = (end_time - start_time).total_seconds()
-            if total_duration < 60:
-                duration_str = f"{total_duration:.1f}s"
-            elif total_duration < 3600:
-                duration_str = f"{total_duration / 60:.1f}m"
-            else:
-                duration_str = f"{total_duration / 3600:.1f}h"
+        duration_str = format_duration(start_time, end_time)
+        if duration_str:
             lines.append(f"• Duration: {duration_str}")
 
         lines.append("")

--- a/app/utils/notifiers/telegram.py
+++ b/app/utils/notifiers/telegram.py
@@ -289,7 +289,6 @@ class TelegramNotifier(BaseNotifier):
                 - containers_failed: int
                 - containers_skipped: int
                 - update_details: List[Dict] with container update details
-                - errors: List[str] (optional)
                 - warnings: List[str] (optional)
 
         Returns:
@@ -304,7 +303,6 @@ class TelegramNotifier(BaseNotifier):
         containers_skipped = update_data.get("containers_skipped", 0)
         update_details = update_data.get("update_details", [])
         skip_details = update_data.get("skip_details", [])
-        errors = update_data.get("errors", [])
         warnings = update_data.get("warnings", [])
         start_time = update_data.get("start_time")
         end_time = update_data.get("end_time")
@@ -399,6 +397,9 @@ class TelegramNotifier(BaseNotifier):
                 lines.append(f"<code>{old_version} → {new_version}</code>")
                 lines.append(f"<code>   {update_type_emoji(update_type)} {update_type}</code>")
                 lines.append(f"<code>   ⏱️ {duration_str}</code>")
+                error_message = detail.get("error_message")
+                if error_message:
+                    lines.append(f"<code>   ❌ {error_message}</code>")
 
             if len(failed_updates) > 10:
                 lines.append(f"... and {len(failed_updates) - 10} more")
@@ -413,15 +414,6 @@ class TelegramNotifier(BaseNotifier):
                 lines.append(f"")
                 lines.append(f"<b>{container_name}</b>")
                 lines.append(f"<code>{reason}</code>")
-            lines.append("")
-
-        # Errors
-        if errors:
-            lines.append("<b>❌ Errors:</b>")
-            for error in errors[:5]:  # Limit to first 5 errors
-                lines.append(f"• {error}")
-            if len(errors) > 5:
-                lines.append(f"   ... and {len(errors) - 5} more")
             lines.append("")
 
         # Warnings

--- a/app/utils/notifiers/telegram.py
+++ b/app/utils/notifiers/telegram.py
@@ -3,7 +3,7 @@ import logging
 import json
 import os
 from .base import BaseNotifier
-from .report import format_duration
+from .report import format_duration, update_type_emoji
 from typing import List, Dict, Any
 from datetime import datetime
 
@@ -352,15 +352,6 @@ class TelegramNotifier(BaseNotifier):
                 update_type = detail.get("update_type", "Unknown")
                 duration = detail.get("duration")
 
-                # Use emoji based on update type
-                type_emoji = {
-                    "major": "🚀",
-                    "minor": "✨",
-                    "patch": "🐞",
-                    "build": "🏗️",
-                    "digest": "📦"
-                }.get(update_type, "⚪")
-
                 # Add duration if available
                 if duration is not None:
                     if duration < 60:
@@ -375,7 +366,7 @@ class TelegramNotifier(BaseNotifier):
                 lines.append(f"")
                 lines.append(f"<b>{container_name}</b>")
                 lines.append(f"<code>{old_version} → {new_version}</code>")
-                lines.append(f"<code>   {type_emoji} {update_type}</code>")
+                lines.append(f"<code>   {update_type_emoji(update_type)} {update_type}</code>")
                 lines.append(f"<code>   ⏱️ {duration_str}</code>")
 
             if len(successful_updates) > 10:
@@ -392,15 +383,6 @@ class TelegramNotifier(BaseNotifier):
                 update_type = detail.get("update_type", "Unknown")
                 duration = detail.get("duration")
 
-                # Use emoji based on update type
-                type_emoji = {
-                    "major": "🚀",
-                    "minor": "✨",
-                    "patch": "🐞",
-                    "build": "🏗️",
-                    "digest": "📦"
-                }.get(update_type, "⚪")
-
                 # Add duration if available
                 if duration is not None:
                     if duration < 60:
@@ -415,7 +397,7 @@ class TelegramNotifier(BaseNotifier):
                 lines.append(f"")
                 lines.append(f"<b>{container_name}</b>")
                 lines.append(f"<code>{old_version} → {new_version}</code>")
-                lines.append(f"<code>   {type_emoji} {update_type}</code>")
+                lines.append(f"<code>   {update_type_emoji(update_type)} {update_type}</code>")
                 lines.append(f"<code>   ⏱️ {duration_str}</code>")
 
             if len(failed_updates) > 10:

--- a/app/utils/notifiers/telegram.py
+++ b/app/utils/notifiers/telegram.py
@@ -303,6 +303,7 @@ class TelegramNotifier(BaseNotifier):
         containers_failed = update_data.get("containers_failed", 0)
         containers_skipped = update_data.get("containers_skipped", 0)
         update_details = update_data.get("update_details", [])
+        skip_details = update_data.get("skip_details", [])
         errors = update_data.get("errors", [])
         warnings = update_data.get("warnings", [])
         start_time = update_data.get("start_time")
@@ -419,6 +420,17 @@ class TelegramNotifier(BaseNotifier):
 
             if len(failed_updates) > 10:
                 lines.append(f"... and {len(failed_updates) - 10} more")
+            lines.append("")
+
+        # Skipped containers
+        if skip_details:
+            lines.append("<b>⏭️ Skipped Containers:</b>")
+            for detail in skip_details:
+                container_name = detail.get("container_name", "Unknown")
+                reason = detail.get("reason", "Unknown")
+                lines.append(f"")
+                lines.append(f"<b>{container_name}</b>")
+                lines.append(f"<code>{reason}</code>")
             lines.append("")
 
         # Errors

--- a/app/utils/registries/__init__.py
+++ b/app/utils/registries/__init__.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from . import docker, ghcr
+from . import docker, ghcr, oci
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +29,11 @@ def get_image_tags(imageName, imageUrl, registry, imageTagsUrl, imageTag):
     """
     logger.debug(f"Retrieving available image tags from '{registry}'", extra={"indent": 2})
     if registry in ["docker.io"]:
-        tags = docker.get_image_tags(imageTagsUrl, imageTag)  # filtered by similar tags, sorted and truncated so only the current tag and newer are listed
+        tags = docker.get_image_tags(imageTagsUrl, imageTag)
     elif registry in ["ghcr.io"]:
-        tags = ghcr.get_image_tags(imageName, imageUrl, imageTagsUrl, imageTag)  # filtered by similar tags, sorted and truncated so only the current tag and newer are listed
+        tags = ghcr.get_image_tags(imageName, imageUrl, imageTagsUrl, imageTag)
+    else:
+        tags = oci.get_image_tags( imageName, imageUrl, imageTagsUrl, imageTag, registry_api_url=f"https://{registry}/v2")
 
     logger.debug(
         f"A total of {len(tags)} image tags relevant for update processing have been retrieved from '{registry}'",

--- a/app/utils/registries/docker.py
+++ b/app/utils/registries/docker.py
@@ -9,6 +9,7 @@ from typing import Optional
 import requests
 
 from ..config import config
+from ..interrupt import check_interrupted
 from . import generic
 from .auth import get_credentials
 
@@ -127,6 +128,8 @@ def get_image_tags(imageTagsUrl, imageTag, max_pages=config.docker.pageCrawlLimi
         logger.debug(f"No authentication configured for Docker Hub (anonymous)", extra={"indent": 2})
 
     while imageTagsUrl:
+        check_interrupted()
+
         if max_pages is not None and page_count >= max_pages:
             break
 

--- a/app/utils/registries/oci.py
+++ b/app/utils/registries/oci.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""OCI Distribution API v2 registry support (GitLab, private registries, etc.)."""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import requests
+
+from ..config import config
+from . import generic
+from .auth import get_auth_headers
+
+logger = logging.getLogger(__name__)
+
+
+def update_url_with_page_size(url: str, page_size: int = config.ghcr.pageSize) -> str:
+    parts = urlparse(url)
+    query = parse_qs(parts.query)
+    query["n"] = [str(page_size)]
+    new_query = urlencode(query, doseq=True)
+    return urlunparse(parts._replace(query=new_query))
+
+
+def _parse_next_url(link_header: str, page_size: int, registry_api_url: str) -> Optional[str]:
+    if not link_header:
+        return None
+    match = re.search(r'<([^>]+)>;\s*rel="next"', link_header)
+    if not match:
+        return None
+    next_url = match.group(1)
+    if not next_url.startswith("http"):
+        registry_root = registry_api_url.removesuffix("/v2")
+        next_url = f"{registry_root}{next_url}"
+    return update_url_with_page_size(next_url, page_size)
+
+
+def fetch_tag_details(imageUrl: str, tags: List[str], headers: Dict[str, str]) -> List[Dict]:
+    manifest_headers = {
+        **headers,
+        "Accept": (
+            "application/vnd.oci.image.index.v1+json,"
+            "application/vnd.docker.distribution.manifest.list.v2+json,"
+            "application/vnd.docker.distribution.manifest.v2+json"
+        ),
+    }
+
+    detailed_tags = []
+
+    for tag in tags:
+        url = f"{imageUrl}/manifests/{tag}"
+        tag_info = {}
+        created = None
+
+        try:
+            response = requests.get(url, headers=manifest_headers, timeout=30)
+            response.raise_for_status()
+            manifest = response.json()
+            media_type = manifest.get("mediaType")
+            header_digest = response.headers.get("Docker-Content-Digest")
+
+            created = manifest.get("annotations", {}).get("org.opencontainers.image.created")
+            if not created:
+                created = manifest.get("created")
+
+            if not created and media_type == "application/vnd.docker.distribution.manifest.v2+json":
+                config_digest = manifest.get("config", {}).get("digest")
+                if config_digest:
+                    config_response = requests.get(
+                        f"{imageUrl}/blobs/{config_digest}",
+                        headers=headers,
+                        timeout=30,
+                    )
+                    if config_response.ok:
+                        created = config_response.json().get("created")
+
+            tag_info = {
+                "name": tag,
+                "last_updated": created,
+                "digest": header_digest,
+                "media_type": media_type,
+            }
+        except requests.RequestException as e:
+            logger.warning(f"Failed to fetch manifest for tag {tag}: {e}", extra={"indent": 4})
+            tag_info = {"name": tag, "last_updated": None, "digest": None}
+
+        detailed_tags.append(tag_info)
+
+    return detailed_tags
+
+
+def get_image_tags(
+    imageName: str,
+    imageUrl: str,
+    imageTagsUrl: str,
+    imageTag: str,
+    registry_api_url: str,
+    max_pages=config.ghcr.pageCrawlLimit,
+) -> List[Any]:
+    """
+    Retrieve and process image tags from an OCI Distribution v2 compatible registry.
+    """
+    tags: List[str] = []
+    page_size = int(config.ghcr.pageSize)
+    auth_headers = get_auth_headers(registry_api_url, imageName)
+    headers = auth_headers if auth_headers else {}
+
+    if headers:
+        logger.debug(f"Using configured authentication for {registry_api_url}", extra={"indent": 2})
+    else:
+        logger.debug(f"No authentication configured for {registry_api_url} (anonymous)", extra={"indent": 2})
+
+    next_url = update_url_with_page_size(imageTagsUrl, page_size)
+
+    for _ in range(max_pages):
+        if not next_url:
+            break
+
+        try:
+            logger.debug(f"Making request to: {next_url}", extra={"indent": 2})
+            response = requests.get(next_url, headers=headers, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+            tags.extend(data.get("tags", []) or [])
+            next_url = _parse_next_url(response.headers.get("Link", ""), page_size, registry_api_url)
+        except requests.RequestException as e:
+            logger.error(f"Error fetching tags from {next_url}: {e}", extra={"indent": 2})
+            break
+
+    logger.debug(f"tags:\n{json.dumps(tags, indent=4)}", extra={"indent": 2})
+    filtered_tags = generic.filter_image_tags(tags, imageTag)
+    logger.debug(f"filtered_tags:\n{json.dumps(filtered_tags, indent=4)}", extra={"indent": 2})
+    sorted_tags = generic.sort_tags(filtered_tags)
+    logger.debug(f"sorted_filtered_tags:\n{json.dumps(sorted_tags, indent=4)}", extra={"indent": 2})
+    truncated_tags = generic.truncate_tags(sorted_tags, imageTag)
+    logger.debug(f"truncated_tags:\n{json.dumps(truncated_tags, indent=4)}", extra={"indent": 2})
+    return fetch_tag_details(imageUrl, truncated_tags, headers)

--- a/app/utils/scripts.py
+++ b/app/utils/scripts.py
@@ -275,6 +275,15 @@ def _run_script_with_timeout(script_path: str, env_vars: Dict[str, str], timeout
             "error": None if process.returncode == 0 else f"Script exited with code {process.returncode}"
         }
 
+    except KeyboardInterrupt:
+        if process and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=2)
+            except Exception:
+                process.kill()
+        raise
+
     except Exception as e:
         if process:
             try:

--- a/app/utils/self_update.py
+++ b/app/utils/self_update.py
@@ -161,7 +161,7 @@ def execute_self_update_from_helper(client, target_container_name, dry_run):
             return
 
         # Recreate the container with the new image
-        new_container = recreate_container(
+        new_container, _ = recreate_container(
             client,
             target_container,
             new_image_reference,

--- a/docs/01-Introduction.md
+++ b/docs/01-Introduction.md
@@ -45,7 +45,7 @@ For a complete feature overview, see the [README](https://github.com/captn-io/ca
 
 Key capabilities that make captn powerful:
 - **Rule-Driven Updates**: Granular policies with conditional requirements and lag policies
-- **Multi-Registry Support**: Docker Hub, GHCR, and private registries
+- **Multi-Registry Support**: Docker Hub, GHCR, and OCI v2 compatible private registries (GitLab, Harbor, etc.)
 - **Progressive Upgrades**: Sequential version updates with verification at each step
 - **Safety Mechanisms**: Dry-run mode, automatic rollback, and verification periods
 - **Notifications**: Real-time updates via Telegram and detailed email reports

--- a/docs/01-Introduction.md
+++ b/docs/01-Introduction.md
@@ -67,7 +67,7 @@ Key capabilities that make captn powerful:
 6. **Verification**: Monitors container stability for configured duration
 7. **Post-Script Execution**: Runs container-specific post-update scripts
 8. **Cleanup**: Removes old images and backup containers if configured
-9. **Notification**: Sends update report via configured channels
+9. **Notification**: Sends update report via configured channels (see [Update Report Reference](03-Configuration.md#update-report-reference) for field meanings)
 
 ### Safety Mechanisms
 

--- a/docs/02-CLI-Reference.md
+++ b/docs/02-CLI-Reference.md
@@ -75,7 +75,7 @@ captn -v
 
 **Example Output:**
 ```
-0.8.6
+0.9.0
 ```
 
 ---
@@ -321,7 +321,7 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v ~/captn/conf:/app/conf \
   -v ~/captn/logs:/app/logs \
-  captnio/captn:0.8.6
+  captnio/captn:0.9.0
 ```
 
 **Note:** The captn Docker image runs in daemon mode by default. The `--daemon` flag is already configured internally and does not need to be specified.
@@ -572,7 +572,7 @@ docker run -d \
   -e TZ=Europe/Berlin \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v ~/captn/conf:/app/conf \
-  captnio/captn:0.8.6
+  captnio/captn:0.9.0
 ```
 
 ### Docker Socket
@@ -586,7 +586,7 @@ captn requires access to the Docker socket to manage containers.
 docker run -d \
   --name captn \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  captnio/captn:0.8.6
+  captnio/captn:0.9.0
 ```
 
 ---

--- a/docs/03-Configuration.md
+++ b/docs/03-Configuration.md
@@ -1713,10 +1713,14 @@ executionTimeout =
 # Possible values: true, false
 # Default: false
 enabled =
-# When to send notifications: changes (default) or all
+# When to send notifications
+# Possible values: changes, all
+#   changes - only on updates, failures, skips, errors, or warnings (recommended)
+#   all     - after every run with at least one container checked (legacy)
 # Default: changes
 sendOn =
 # Send notifications for dry-run executions
+# Possible values: true, false
 # Default: true
 sendOnDryRun =
 

--- a/docs/03-Configuration.md
+++ b/docs/03-Configuration.md
@@ -15,9 +15,11 @@ This document provides a comprehensive reference for all captn configuration opt
   - [selfUpdate](#selfupdate)
   - [preScripts](#prescripts)
   - [postScripts](#postscripts)
+  - [Registry Support](#registry-support)
   - [docker](#docker)
   - [ghcr](#ghcr)
   - [registryAuth](#registryauth)
+    - [registry-credentials.json](#registry-credentialsjson)
   - [envFiltering](#envfiltering)
   - [notifiers](#notifiers)
     - [Update Report Reference](#update-report-reference)
@@ -562,9 +564,55 @@ rollbackOnFailure = true
 
 ---
 
+## Registry Support
+
+captn discovers available image tags from the registry referenced in each container's image. The registry type is detected automatically from the image reference.
+
+### How registries are detected
+
+From an image reference like `registry.example.com/myorg/myapp:1.2.3`, captn extracts:
+
+| Component     | Example                |
+| ------------- | ---------------------- |
+| Registry host | `registry.example.com` |
+| Repository    | `myorg/myapp`          |
+| Tag           | `1.2.3`                |
+
+Detection rules:
+
+- **No hostname** (e.g. `nginx:1.25`): `docker.io` (Docker Hub, `library/` namespace implied)
+- **Hostname without dot** (e.g. `myorg/myapp:1.0`): `docker.io`
+- **Hostname with dot** (e.g. `ghcr.io/org/app:1.0`): registry host is the first path segment
+
+API URLs are built as `https://{registry}/v2/{repository}` for all non-Docker-Hub registries.
+
+### Supported registry types
+
+| Registry                      | Example image                        | Tag discovery                                  | Config section |
+| ----------------------------- | ------------------------------------ | ---------------------------------------------- | -------------- |
+| **Docker Hub**                | `nginx:1.25`, `library/mariadb:11.4` | Docker Hub REST API (`/repositories/.../tags`) | `[docker]`     |
+| **GitHub Container Registry** | `ghcr.io/org/app:1.0`                | GHCR-specific API and token flow               | `[ghcr]`       |
+| **OCI v2 compatible**         | `registry.my-domain.com/org/app:1.0` | OCI Distribution API (`/v2/.../tags/list`)     | `[ghcr]`       |
+
+### Authentication for private registries
+
+Private or authenticated registries require `[registryAuth]` to be enabled and a credentials file — see [registry-credentials.json](#registry-credentialsjson) for the full reference.
+
+Authentication is used for both **tag discovery** and **image pulls**.
+
+### Limitations
+
+- **OCI v2 required:** The registry must support the Distribution API endpoint `GET /v2/{repository}/tags/list`. Registries with non-standard APIs are not supported.
+- **`latest` tag:** Containers pinned to `latest` may not receive semver-based update suggestions, because tag filtering requires a concrete version string to match against. Prefer explicit version tags (e.g. `1.2.3`) where updates are desired.
+- **Pagination:** OCI v2 registries use `pageCrawlLimit` and `pageSize` from `[ghcr]` (defaults: 1000 pages × 100 tags).
+
+---
+
 ### `[docker]`
 
 Docker Hub registry configuration.
+
+**Applies to:** images from `docker.io` only (including unprefixed names like `nginx:1.25`).
 
 #### `apiUrl`
 
@@ -579,7 +627,7 @@ Docker Hub API URL for fetching image metadata.
 apiUrl = https://registry.hub.docker.com/v2
 ```
 
-**Note:** Usually doesn't need to be changed unless using a custom registry.
+**Note:** This section configures the Docker Hub API only. It does not apply to private or custom registries — those use OCI v2 automatically (see [Registry Support](#registry-support)).
 
 #### `pageCrawlLimit`
 
@@ -698,10 +746,11 @@ enabled = false
 
 #### `credentialsFile`
 
-Path to JSON file containing registry credentials.
+Path to the JSON credentials file (see [registry-credentials.json](#registry-credentialsjson)).
 
 - **Type:** String (path)
 - **Default:** `/app/conf/registry-credentials.json`
+- **Required when:** `[registryAuth] enabled = true` (The file must exist and contain valid JSON)
 
 **Example:**
 ```ini
@@ -709,7 +758,52 @@ Path to JSON file containing registry credentials.
 credentialsFile = /app/conf/registry-credentials.json
 ```
 
-**Credentials File Format:**
+#### registry-credentials.json
+
+Credentials for private container registries. Referenced by `credentialsFile` in `[registryAuth]`.
+
+**Default location:** `/app/conf/registry-credentials.json` (mount your config directory to `/app/conf` in Docker)
+
+**File requirements:**
+
+- Valid JSON format
+- One or both top-level keys: `registries`, `repositories` (either may be omitted or empty)
+
+**Top-level structure:**
+
+| Key            | Purpose                                                                           |
+| -------------- | --------------------------------------------------------------------------------- |
+| `registries`   | Credentials applied to **all** repositories on a registry                         |
+| `repositories` | Credentials for a **specific** repository — overrides `registries` for that image |
+
+**Authentication priority:**
+
+1. Repository-specific entry in `repositories` (if the image repository name matches)
+2. Registry-level entry in `registries` (matched by API URL `https://{hostname}/v2`)
+3. No authentication (anonymous access)
+
+##### Registry keys (`registries`)
+
+Use the registry **API URL** including the `/v2` suffix:
+
+| Image                              | Registry key                         |
+| ---------------------------------- | ------------------------------------ |
+| `nginx:1.25`                       | `https://registry.hub.docker.com/v2` |
+| `ghcr.io/org/app:1.0`              | `https://ghcr.io/v2`                 |
+| `registry.example.com/org/app:1.0` | `https://registry.example.com/v2`    |
+
+captn also attempts partial hostname matching (e.g. configured `example.com` may match `registry.example.com`).
+
+##### Repository keys (`repositories`)
+
+Use the repository path **without** the registry hostname, e.g.:
+
+| Image reference                              | Repository key      |
+| -------------------------------------------- | ------------------- |
+| `captnio/captn:1.0`                          | `captnio/captn`     |
+| `registry.example.com/myorg/private-app:2.0` | `myorg/private-app` |
+| `ghcr.io/myorg/private-app:2.0`              | `myorg/private-app` |
+
 ```json
 {
     "registries": {
@@ -719,6 +813,10 @@ credentialsFile = /app/conf/registry-credentials.json
         },
         "https://ghcr.io/v2": {
             "token": "your_github_personal_access_token"
+        },
+        "https://registry.example.com/v2": {
+            "username": "your-gitlab-username",
+            "password": "glpat-xxxxxxxxxxxx"
         }
     },
     "repositories": {
@@ -728,21 +826,51 @@ credentialsFile = /app/conf/registry-credentials.json
         },
         "myorg/private-repo": {
             "token": "specific_token_for_private_repo"
+        },
+        "myorg/subgroup/private-app": {
+            "username": "deploy-token-user",
+            "password": "glpat-xxxxxxxxxxxx"
         }
     }
 }
 ```
 
-**Structure:**
-- `registries`: Registry-level credentials (apply to all images from that registry)
-- `repositories`: Repository-specific credentials (override registry-level credentials)
+If both `registries` and `repositories` define credentials for the same image, **repository entries take precedence**.
 
-**Authentication Priority:**
-1. Repository-specific credentials (if defined)
-2. Registry-level credentials (if defined)
-3. No authentication
+##### Minimal examples
 
-**Complete Example:**
+Docker Hub only:
+
+```json
+{
+    "registries": {
+        "https://registry.hub.docker.com/v2": {
+            "username": "myuser",
+            "password": "dckr_pat_xxxxxxxx"
+        }
+    }
+}
+```
+
+Single private GitLab project (repository-level):
+
+```json
+{
+    "repositories": {
+        "myorg/subgroup/my-app": {
+            "username": "gitlab-ci-token",
+            "password": "glpat-xxxxxxxxxxxx"
+        }
+    }
+}
+```
+
+##### Security notes
+
+- Store `registry-credentials.json` alongside `captn.cfg` in your mounted config directory
+- Restrict file permissions (e.g. `chmod 600`)
+
+**Complete `[registryAuth]` example:**
 ```ini
 [registryAuth]
 enabled = true
@@ -1966,8 +2094,8 @@ timeout =
 rollbackOnFailure =
 
 [docker]
-# Docker Hub API URL for fetching image metadata
-# Usually doesn't need to be changed unless using a custom registry
+# Docker Hub API URL only
+# Usually doesn't need to be changed
 # Possible values: Valid HTTP/HTTPS URL
 #   Examples: "https://registry.hub.docker.com/v2", "https://custom.registry.com/v2"
 # Default: "https://registry.hub.docker.com/v2"

--- a/docs/03-Configuration.md
+++ b/docs/03-Configuration.md
@@ -2094,8 +2094,8 @@ timeout =
 rollbackOnFailure =
 
 [docker]
-# Docker Hub API URL only
-# Usually doesn't need to be changed
+# Docker Hub API URL for fetching image metadata
+# Usually doesn't need to be changed unless using a custom registry
 # Possible values: Valid HTTP/HTTPS URL
 #   Examples: "https://registry.hub.docker.com/v2", "https://custom.registry.com/v2"
 # Default: "https://registry.hub.docker.com/v2"

--- a/docs/03-Configuration.md
+++ b/docs/03-Configuration.md
@@ -909,6 +909,40 @@ enabled = false
 
 **Note:** Even if individual notifiers are enabled, they won't work if this is `false`.
 
+#### `sendOn`
+
+Control when update reports are sent.
+
+- **Type:** String
+- **Default:** `changes`
+- **Values:**
+  - `changes` — only when at least one update, failure, skip, error, or warning occurred (recommended)
+  - `all` — after every run where at least one container was checked, even if nothing changed
+
+**Example:**
+```ini
+[notifiers]
+sendOn = changes
+```
+
+With `sendOn = changes`, a run that checked containers but found no updates, failures, or skips will **not** send Telegram or email notifications.
+
+#### `sendOnDryRun`
+
+Send notifications for dry-run executions.
+
+- **Type:** Boolean
+- **Default:** `true`
+- **Values:** `true`, `false`
+
+**Example:**
+```ini
+[notifiers]
+sendOnDryRun = false
+```
+
+Set to `false` to suppress notifications when running `captn --dry-run`.
+
 ---
 
 ### `[notifiers.telegram]`
@@ -1679,6 +1713,12 @@ executionTimeout =
 # Possible values: true, false
 # Default: false
 enabled =
+# When to send notifications: changes (default) or all
+# Default: changes
+sendOn =
+# Send notifications for dry-run executions
+# Default: true
+sendOnDryRun =
 
 [notifiers.telegram]
 # Enable Telegram notifications

--- a/docs/03-Configuration.md
+++ b/docs/03-Configuration.md
@@ -20,6 +20,7 @@ This document provides a comprehensive reference for all captn configuration opt
   - [registryAuth](#registryauth)
   - [envFiltering](#envfiltering)
   - [notifiers](#notifiers)
+    - [Update Report Reference](#update-report-reference)
   - [notifiers.telegram](#notifierstelegram)
   - [notifiers.email](#notifiersemail)
   - [assignments](#assignments)
@@ -943,7 +944,19 @@ sendOnDryRun = false
 
 Set to `false` to suppress notifications when running `captn --dry-run`.
 
----
+#### Update Report Reference
+
+After each update run, captn can send a report via Telegram and/or email. Both channels use the same underlying statistics. This section explains what each part of the report means.
+
+**Summary**
+
+| Counter      | Counts       | Meaning                                                                                              |
+| ------------ | ------------ | ---------------------------------------------------------------------------------------------------- |
+| **Checked**  | Containers   | Passed rule pre-check and were inspected (metadata and remote tags fetched)                          |
+| **Updated**  | Update steps | Successful updates applied or simulated; progressive upgrades produce multiple entries per container |
+| **Failed**   | Errors       | Errors recorded during the run (inspect, script, or recreation failures)                             |
+| **Skipped**  | Containers   | If a containers assigned rule allows no updates, or registry returned no tags                        |
+| **Duration** | Run          | Total elapsed time of the update run                                                                 |
 
 ### `[notifiers.telegram]`
 


### PR DESCRIPTION
### Notifications
* feat: add `sendOn` configuration (`changes` | `all`) to control when Telegram and email reports are sent
* feat: add `sendOnDryRun` to enable or disable notifications during dry-run executions
* fix: remove misleading email status banner when containers were checked but no updates, failures, or skips occurred
* fix: rename summary label **Processed** to **Checked** in Telegram and email reports
* refactor: centralize notification report logic in `app/utils/notifiers/report.py`
* refactor: remove entry limits in email update reports (list all updates, errors, and warnings)
* chore: remove captn version in mail header and subject to reduce redundancy (version already displayed in footer)
* chore: remove emoticons from email reports (use monotone UI symbols instead)
* chore: unified colors in email report
* feat: group errors by container in Telegram and email reports
* fix: center email logo reliably in Apple Mail (table layout, explicit inline dimensions)

### Documentation
* docs: document `sendOn` and `sendOnDryRun` in configuration reference
* docs: add **Update Report Reference** under `[notifiers]` (Checked, Updated, Failed, Skipped, errors, status banner, update details)
* docs: expand `registry-credentials.json` reference

### Bug Fixes
* fix: allow Ctrl+C to interrupt running captn updates (`captn.sh` no longer swallows SIGINT)
   * fix: run Python directly without `timeout` wrapper in interactive sessions (TTY)
   * fix: propagate KeyboardInterrupt during image pulls and pre/post script execution
   * fix: skip real startup verification loop during dry-run
   * fix: make Docker Hub tag crawl interruptible between pagination requests
* fix: report correct from-version for each progressive dry-run update in notifications
* fix: UnboundLocalError for `tags` when using custom registries (e.g. GitLab self-hosted registries)

### New Features
* feat: support OCI v2 registries (e.g. GitLab, private registries)
* feat: list skipped containers with reason in Telegram and email reports
